### PR TITLE
Updated README.md

### DIFF
--- a/certified-kubernetes-administrator/README.md
+++ b/certified-kubernetes-administrator/README.md
@@ -105,7 +105,7 @@ mkcd() { mkdir -p "$@" && cd "$@" ; }
 
 ## create/destroy from yaml faster
 alias kaf='k apply -f '
-alias kdf='k destroy -f '
+alias kdf='k delete -f '
 
 ## namespaces (poor man's `kubens`)
 export nk='-n kube-system'


### PR DESCRIPTION
changed the alias typo for kdf from
`k destroy -f ` --> `k delete -f`